### PR TITLE
fix: Use semantic release for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive"
+    "test": "jenkins-mocha --recursive",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
@@ -45,5 +46,11 @@
     "screwdriver-executor-base": "^5.2.0",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"
+  },
+  "release": {
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,11 +12,10 @@ jobs:
 
     publish:
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
-            - install-ci: npm install npm-auto-version
-            - publish-npm: ./ci/publish.sh
+            - install: npm install semantic-release
+            - publish: npm run semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN
             # Pushing tags to Git
-            - GIT_KEY
+            - GH_TOKEN


### PR DESCRIPTION
Currenly a publish job pushes a tag by git command due to old pipeline. 
I changed the publish job to use semantic release as other pipelines do.