### PR TITLE
feat: set store uri when launch

### DIFF
--- a/config/docker-compose.yml.tim
+++ b/config/docker-compose.yml.tim
@@ -29,6 +29,6 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/launch --api-uri {{api_uri}} --emitter /opt/sd/emitter {{build_id}} &
+          /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
           /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{store_uri}} --build {{build_id}} &
           wait $$(jobs -p)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "jenkins-mocha --recursive --timeout 15000",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,7 +55,8 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/launch --api-uri {{api_uri}} --emitter /opt/sd/emitter {{build_id}} &
+          /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} \
+          --emitter /opt/sd/emitter {{build_id}} &
           /opt/sd/logservice --api-uri {{store_uri}} --build {{build_id}} &
           wait $(jobs -p)
 `;


### PR DESCRIPTION
## Context
Add store url argument when call launch command.

We need to use store url when use sd-cmd. 
By this [PR](https://github.com/screwdriver-cd/launcher/pull/138), we can set store api. 

## Objective
Call launch command with `--store-uri` argument.

When I try to test by Screwdriver, it failed as timeout. So I add flag of timeout to jenkins-mocha test.

## References
[launcher PR for store url argument](https://github.com/screwdriver-cd/launcher/pull/138)
  
  