### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "Min Zhang <minzhang@andrew.cmu.edu>",
     "Noah Katzman <nbkatzman@gmail.com>",
     "Peter Peterson <jedipetey@gmail.com>",
+    "Philip Scott <pscott@zeptohost.com>",
     "St. John Johnson <st.john.johnson@gmail.com",
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it. Aside from maintenance, upgrading to Node.js 8 also provides async functions, which simplify `Promise` control flow.

## Objective

* Change image in `screwdriver.yaml` to `node:8`
* Convert some functions that return a `Promise` to `async` functions