### PR TITLE
[2] fix: add start/stop periodic functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,6 +301,24 @@ class JenkinsExecutor extends Executor {
             params: [{ name: jobName }]
         });
     }
+
+    /**
+     * Starts a new periodic build in an executor
+     * @method _startPeriodic
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    async _startPeriodic() {
+        return Promise.resolve(null);
+    }
+
+    /**
+     * Stops a new periodic build in an executor
+     * @method _stopPeriodic
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    async _stopPeriodic() {
+        return Promise.resolve(null);
+    }
 }
 
 module.exports = JenkinsExecutor;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "circuit-fuses": "^2.2.1",
     "jenkins": "^0.20.0",
     "request": "^2.72.0",
-    "screwdriver-executor-base": "^5.2.0",
+    "screwdriver-executor-base": "^6.1.0",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -394,6 +394,14 @@ describe('index', () => {
         });
     });
 
+    describe('periodic', () => {
+        it('resolves to null when calling periodic start',
+            () => executor.startPeriodic().then(res => assert.isNull(res)));
+
+        it('resolves to null when calling periodic stop',
+            () => executor.stopPeriodic().then(res => assert.isNull(res)));
+    });
+
     describe('_loadJobXml', () => {
         let fsMock;
 


### PR DESCRIPTION
Resolving to `null` since it's not supported. 
We need this because models always call `_startPeriodic` for `update`

Blocked by: https://github.com/screwdriver-cd/executor-base/pull/39
Related: https://github.com/screwdriver-cd/screwdriver/issues/688