### PR TITLE
fix(1030): [2] Add to call method in executor-base to get JWT for build

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,8 +268,10 @@ class JenkinsExecutor extends Executor {
         await this._jenkinsJobCreateOrUpdate(jobName, xml);
 
         // exchange temporal JWT to build JWT
-        return this.exchangeTokenForBuild(config).then(() =>
-            this.breaker.runCommand({
+        return this.exchangeTokenForBuild(config).then((buildToken) => {
+            config.token = buildToken;
+
+            return this.breaker.runCommand({
                 module: 'job',
                 action: 'build',
                 params: [{
@@ -282,8 +284,8 @@ class JenkinsExecutor extends Executor {
                         SD_STORE: this.ecosystem.store
                     }
                 }]
-            })
-        );
+            });
+        });
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -267,20 +267,23 @@ class JenkinsExecutor extends Executor {
 
         await this._jenkinsJobCreateOrUpdate(jobName, xml);
 
-        return this.breaker.runCommand({
-            module: 'job',
-            action: 'build',
-            params: [{
-                name: jobName,
-                parameters: {
-                    SD_BUILD_ID: String(config.buildId),
-                    SD_TOKEN: config.token,
-                    SD_CONTAINER: config.container,
-                    SD_API: this.ecosystem.api,
-                    SD_STORE: this.ecosystem.store
-                }
-            }]
-        });
+        // exchange temporal JWT to build JWT
+        return this.exchangeTokenForBuild(config).then(() =>
+            this.breaker.runCommand({
+                module: 'job',
+                action: 'build',
+                params: [{
+                    name: jobName,
+                    parameters: {
+                        SD_BUILD_ID: String(config.buildId),
+                        SD_TOKEN: config.token,
+                        SD_CONTAINER: config.container,
+                        SD_API: this.ecosystem.api,
+                        SD_STORE: this.ecosystem.store
+                    }
+                }]
+            })
+        );
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -180,6 +180,7 @@ describe('index', () => {
         let configOpts;
         let existsOpts;
         let buildOpts;
+        let exchangeTokenStub;
         const fakeXml = 'fake_xml';
 
         beforeEach(() => {
@@ -211,6 +212,8 @@ describe('index', () => {
             };
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves();
         });
 
         it('return null when the job is successfully created', (done) => {
@@ -569,6 +572,7 @@ rm -f docker-compose.yml
 
     describe('run without Mocked Breaker', () => {
         const fakeXml = 'fake_xml';
+        let exchangeTokenStub;
 
         beforeEach(() => {
             mockery.deregisterMock('circuit-fuses');
@@ -593,6 +597,8 @@ rm -f docker-compose.yml
             jenkinsMock.job.build = sinon.stub(executor.jenkinsClient.job, 'build');
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves();
         });
 
         it('calls jenkins function correctly', (done) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,7 +89,7 @@ describe('index', () => {
 
     const buildParameters = {
         SD_BUILD_ID: String(config.buildId),
-        SD_TOKEN: config.token,
+        SD_TOKEN: 'someBuildToken',
         SD_CONTAINER: config.container,
         SD_API: ecosystem.api,
         SD_STORE: ecosystem.store
@@ -213,7 +213,7 @@ describe('index', () => {
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
         });
 
         it('return null when the job is successfully created', (done) => {
@@ -598,7 +598,7 @@ rm -f docker-compose.yml
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
         });
 
         it('calls jenkins function correctly', (done) => {


### PR DESCRIPTION
## Objective 
- When build starts in executor, call [`exchangeTokenForBuild()`](https://github.com/screwdriver-cd/executor-base/pull/42) method which is added in `executor-base` to get build JWT, and replace `config.token` to the new JWT.

## References
- Issues: 
　https://github.com/screwdriver-cd/screwdriver/issues/998
　https://github.com/screwdriver-cd/screwdriver/issues/1030
　https://github.com/screwdriver-cd/screwdriver/issues/1075
- Related: (other PRs)
　https://github.com/screwdriver-cd/screwdriver/pull/1087
　https://github.com/screwdriver-cd/models/pull/245
　https://github.com/screwdriver-cd/executor-base/pull/42
　https://github.com/screwdriver-cd/executor-k8s/pull/84
　https://github.com/screwdriver-cd/executor-k8s-vm/pull/33
　https://github.com/screwdriver-cd/executor-docker/pull/25
　https://github.com/screwdriver-cd/executor-jenkins/pull/20

## TODO
- [x] Add unit test