### PR TITLE
Configure build timeout in Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.jenkins.host | String | | The hostname for the Jenkins cluster |
 | config.jenkins.port | Number | 8080 | The port number for the Jenkins cluster |
 | config.jenkins.nodeLabel | String | 'screwdriver' | Node labels of Jenkins slaves |
-| config.jenkins.buildTimeout | Number | 90 | Number of minutes to allow a build to run before considering it is timed out | 
+| config.jenkins.buildTimeout | Number | 90 | Number of minutes to allow a build to run before considering it is timed out |
 | config.jenkins.maxBuildTimeout | Number | 120 | Max timeout user can configure up to |
 | config.docker.composeCommand | String | 'docker'-compose | The path to the docker-compose command |
 | config.docker.launchVersion | String | 'stable' | Launcher container version to use |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The class provides a couple options that are configurable in the instantiation o
 | config.jenkins.host | String | | The hostname for the Jenkins cluster |
 | config.jenkins.port | Number | 8080 | The port number for the Jenkins cluster |
 | config.jenkins.nodeLabel | String | 'screwdriver' | Node labels of Jenkins slaves |
+| config.jenkins.buildTimeout | Number | 90 | Number of minutes to allow a build to run before considering it is timed out |
+| config.jenkins.maxBuildTimeout | Number | 120 | Max timeout user can configure up to |
 | config.docker.composeCommand | String | 'docker'-compose | The path to the docker-compose command |
 | config.docker.launchVersion | String | 'stable' | Launcher container version to use |
 | config.docker.prefix | String | '' | Prefix to container names |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.jenkins.host | String | | The hostname for the Jenkins cluster |
 | config.jenkins.port | Number | 8080 | The port number for the Jenkins cluster |
 | config.jenkins.nodeLabel | String | 'screwdriver' | Node labels of Jenkins slaves |
-| config.jenkins.buildTimeout | Number | 90 | Number of minutes to allow a build to run before considering it is timed out |
+| config.jenkins.buildTimeout | Number | 90 | Number of minutes to allow a build to run before considering it is timed out | 
 | config.jenkins.maxBuildTimeout | Number | 120 | Max timeout user can configure up to |
 | config.docker.composeCommand | String | 'docker'-compose | The path to the docker-compose command |
 | config.docker.launchVersion | String | 'stable' | Launcher container version to use |

--- a/config/job.xml.tim
+++ b/config/job.xml.tim
@@ -30,6 +30,11 @@
                     <description/>
                     <defaultValue/>
                 </hudson.model.TextParameterDefinition>
+                <hudson.model.TextParameterDefinition>
+                    <name>SD_BUILD_TIMEOUT</name>
+                    <description/>
+                    <defaultValue/>
+                </hudson.model.TextParameterDefinition>
             </parameterDefinitions>
         </hudson.model.ParametersDefinitionProperty>
     </properties>

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class JenkinsExecutor extends Executor {
         this.username = options.jenkins.username || 'screwdriver';
         this[password] = options.jenkins.password;
         this.nodeLabel = options.jenkins.nodeLabel || 'screwdriver';
-        this.buildTimeout = hoek.reach(options, 'jenkins.buildTimeout') || 90;
+        this.buildTimeout = options.jenkins.buildTimet || 90;
         this.maxBuildTimeout = options.jenkins.maxBuildTimeout || 120;
         this.composeCommand = (options.docker && options.docker.composeCommand) || 'docker-compose';
         this.launchVersion = (options.docker && options.docker.launchVersion) || 'stable';

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class JenkinsExecutor extends Executor {
         this.username = options.jenkins.username || 'screwdriver';
         this[password] = options.jenkins.password;
         this.nodeLabel = options.jenkins.nodeLabel || 'screwdriver';
-        this.buildTimeout = options.jenkins.buildTimet || 90;
+        this.buildTimeout = options.jenkins.buildTimeout || 90;
         this.maxBuildTimeout = options.jenkins.maxBuildTimeout || 120;
         this.composeCommand = (options.docker && options.docker.composeCommand) || 'docker-compose';
         this.launchVersion = (options.docker && options.docker.launchVersion) || 'stable';

--- a/index.js
+++ b/index.js
@@ -6,9 +6,12 @@ const jenkins = require('jenkins');
 const xmlescape = require('xml-escape');
 const tinytim = require('tinytim');
 const Breaker = require('circuit-fuses');
+const hoek = require('hoek');
 
 const password = Symbol('password');
 const baseUrl = Symbol('baseUrl');
+
+const ANNOTATE_BUILD_TIMEOUT = 'beta.screwdriver.cd/timeout';
 
 class JenkinsExecutor extends Executor {
     /**
@@ -211,6 +214,8 @@ class JenkinsExecutor extends Executor {
      * @param  {String} [options.jenkins.username='screwdriver']       Jenkins username
      * @param  {String} options.jenkins.password                       Jenkins password/token
      * @param  {String} [options.jenkins.nodeLabel='screwdriver']      Node labels of Jenkins slaves
+     * @param  {Number} [options.jenkins.buildTimeout=90]              Number of minutes to allow a build to run before considering it is
+     * @param  {Number} [options.jenkins.maxBuildTimeout=120]          Max timeout user can configure up to
      * @param  {String} [options.docker.composeCommand='docker-compose']    THe path to the docker-compose command
      * @param  {String} [options.docker.launchVersion='stable']        Launcher container version to use
      * @param  {String} [options.docker.prefix='']                     Prefix to all container names
@@ -230,6 +235,8 @@ class JenkinsExecutor extends Executor {
         this.username = options.jenkins.username || 'screwdriver';
         this[password] = options.jenkins.password;
         this.nodeLabel = options.jenkins.nodeLabel || 'screwdriver';
+        this.buildTimeout = hoek.reach(options, 'jenkins.buildTimeout') || 90;
+        this.maxBuildTimeout = options.jenkins.maxBuildTimeout || 120;
         this.composeCommand = (options.docker && options.docker.composeCommand) || 'docker-compose';
         this.launchVersion = (options.docker && options.docker.launchVersion) || 'stable';
         this.prefix = (options.docker && options.docker.prefix) || '';
@@ -264,6 +271,11 @@ class JenkinsExecutor extends Executor {
     async _start(config) {
         const jobName = this._jobName(config.buildId);
         const xml = this._loadJobXml(config);
+        const annotations = hoek.reach(config, 'annotations', { default: {} });
+
+        const buildTimeout = annotations[ANNOTATE_BUILD_TIMEOUT]
+            ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.maxBuildTimeout)
+            : this.buildTimeout;
 
         await this._jenkinsJobCreateOrUpdate(jobName, xml);
 
@@ -281,7 +293,8 @@ class JenkinsExecutor extends Executor {
                         SD_TOKEN: config.token,
                         SD_CONTAINER: config.container,
                         SD_API: this.ecosystem.api,
-                        SD_STORE: this.ecosystem.store
+                        SD_STORE: this.ecosystem.store,
+                        SD_BUILD_TIMEOUT: buildTimeout
                     }
                 }]
             });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.2.1",
+    "hoek": "^5.0.3",
     "jenkins": "^0.20.0",
     "request": "^2.72.0",
     "screwdriver-executor-base": "^6.1.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,20 +101,12 @@ describe('index', () => {
     };
 
     const maxTimeoutBuildParams = {
-        SD_BUILD_ID: String(config.buildId),
-        SD_TOKEN: 'someBuildToken',
-        SD_CONTAINER: config.container,
-        SD_API: ecosystem.api,
-        SD_STORE: ecosystem.store,
+        ...buildParams,
         SD_BUILD_TIMEOUT: MAX_BUILD_TIMEOUT
     };
 
     const configuredTimeoutBuildParams = {
-        SD_BUILD_ID: String(config.buildId),
-        SD_TOKEN: 'someBuildToken',
-        SD_CONTAINER: config.container,
-        SD_API: ecosystem.api,
-        SD_STORE: ecosystem.store,
+        ...buildParams,
         SD_BUILD_TIMEOUT: CONFIGURED_BUILD_TIMEOUT
     };
 


### PR DESCRIPTION
## Context
This PR implements that users can configure build timeout in Jenkins.

## Objective
Use the annotation for users to configure their own build timeouts in Jenkins.
As below...
```
annotations:
      beta.screwdriver.cd/executor: jenkins
      beta.screwdriver.cd/timeout: 30
```

## References
screwdriver-cd/screwdriver PR: https://github.com/screwdriver-cd/screwdriver/pull/1207
issue: https://github.com/screwdriver-cd/screwdriver/issues/1159