### PR TITLE
feat(1167): [2][small]remove calling exchangeTokenForBuild method

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,24 +267,19 @@ class JenkinsExecutor extends Executor {
 
         await this._jenkinsJobCreateOrUpdate(jobName, xml);
 
-        // exchange temporal JWT to build JWT
-        return this.exchangeTokenForBuild(config).then((buildToken) => {
-            config.token = buildToken;
-
-            return this.breaker.runCommand({
-                module: 'job',
-                action: 'build',
-                params: [{
-                    name: jobName,
-                    parameters: {
-                        SD_BUILD_ID: String(config.buildId),
-                        SD_TOKEN: config.token,
-                        SD_CONTAINER: config.container,
-                        SD_API: this.ecosystem.api,
-                        SD_STORE: this.ecosystem.store
-                    }
-                }]
-            });
+        return this.breaker.runCommand({
+            module: 'job',
+            action: 'build',
+            params: [{
+                name: jobName,
+                parameters: {
+                    SD_BUILD_ID: String(config.buildId),
+                    SD_TOKEN: config.token,
+                    SD_CONTAINER: config.container,
+                    SD_API: this.ecosystem.api,
+                    SD_STORE: this.ecosystem.store
+                }
+            }]
         });
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,7 +89,7 @@ describe('index', () => {
 
     const buildParameters = {
         SD_BUILD_ID: String(config.buildId),
-        SD_TOKEN: 'someBuildToken',
+        SD_TOKEN: config.token,
         SD_CONTAINER: config.container,
         SD_API: ecosystem.api,
         SD_STORE: ecosystem.store
@@ -180,7 +180,6 @@ describe('index', () => {
         let configOpts;
         let existsOpts;
         let buildOpts;
-        let exchangeTokenStub;
         const fakeXml = 'fake_xml';
 
         beforeEach(() => {
@@ -212,8 +211,6 @@ describe('index', () => {
             };
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
         });
 
         it('return null when the job is successfully created', (done) => {
@@ -572,7 +569,6 @@ rm -f docker-compose.yml
 
     describe('run without Mocked Breaker', () => {
         const fakeXml = 'fake_xml';
-        let exchangeTokenStub;
 
         beforeEach(() => {
             mockery.deregisterMock('circuit-fuses');
@@ -597,8 +593,6 @@ rm -f docker-compose.yml
             jenkinsMock.job.build = sinon.stub(executor.jenkinsClient.job, 'build');
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
         });
 
         it('calls jenkins function correctly', (done) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,6 +195,8 @@ describe('index', () => {
         let configOpts;
         let existsOpts;
         let buildOpts;
+        let configuredBuildTimeoutOpts;
+        let maxBuildTimeoutOpts;
         const fakeXml = 'fake_xml';
 
         beforeEach(() => {
@@ -244,6 +246,7 @@ describe('index', () => {
             };
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
+            config.annotations = {};
         });
 
         it('return null when the job is successfully created', (done) => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For issue https://github.com/screwdriver-cd/screwdriver/issues/1167 , we should exchange temporary JWT token in launcher, not in executor-*.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
I removed calling exchangeTokenForBuild method form executor-jenkins.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
related PR:
launcher: https://github.com/screwdriver-cd/launcher/pull/201
executor-k8s: https://github.com/screwdriver-cd/executor-k8s/pull/88
executor-k8s-vm: https://github.com/screwdriver-cd/executor-k8s-vm/pull/35
executor-docker: https://github.com/screwdriver-cd/executor-docker/pull/27