### PR TITLE
feat(1167): [5][small] Use wrapper script

### DIFF
--- a/config/docker-compose.yml.tim
+++ b/config/docker-compose.yml.tim
@@ -29,6 +29,7 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
+          SD_TOKEN=`/opt/sd/launch --fetch-flag --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}}` &&
+          (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
           /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
-          wait $$(jobs -p)
+          wait $$(jobs -p))

--- a/config/docker-compose.yml.tim
+++ b/config/docker-compose.yml.tim
@@ -27,4 +27,4 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/run.sh "{{token}}" {{api_uri}} {{store_uri}} $SD_BUILD_TIMEOUT {{build_id}}
+          /opt/sd/run.sh "{{token}}" "{{api_uri}}" "{{store_uri}}" "$SD_BUILD_TIMEOUT" "{{build_id}}"

--- a/config/docker-compose.yml.tim
+++ b/config/docker-compose.yml.tim
@@ -29,7 +29,7 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          SD_TOKEN=`/opt/sd/launch --fetch-flag --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}}` &&
+          SD_TOKEN=`/opt/sd/launch --only-fetch-token --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}}` &&
           (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
           /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
           wait $$(jobs -p))

--- a/config/docker-compose.yml.tim
+++ b/config/docker-compose.yml.tim
@@ -19,8 +19,6 @@ services:
       sdbuild: {{build_id_with_prefix}}
     mem_limit: {{memory}}
     memswap_limit: {{memory_swap}}
-    environment:
-      SD_TOKEN:
     volumes_from:
       - launcher:rw
     entrypoint: /opt/sd/tini
@@ -29,7 +27,4 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          SD_TOKEN=`/opt/sd/launch --only-fetch-token --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}}` &&
-          (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
-          /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
-          wait $$(jobs -p))
+          /opt/sd/run.sh "{{token}}" {{api_uri}} {{store_uri}} $SD_BUILD_TIMEOUT {{build_id}}

--- a/index.js
+++ b/index.js
@@ -162,6 +162,7 @@ class JenkinsExecutor extends Executor {
             launcher_version: this.launchVersion,
             build_id: config.buildId,
             build_id_with_prefix: `${this.prefix}${config.buildId}`,
+            token: config.token,
             base_image: config.container,
             memory: this.memory,
             memory_swap: this.memoryLimit,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,7 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/run.sh "{{token}}" {{api_uri}} {{store_uri}} $SD_BUILD_TIMEOUT {{build_id}}
+          /opt/sd/run.sh "{{token}}" "{{api_uri}}" "{{store_uri}}" "$SD_BUILD_TIMEOUT" "{{build_id}}"
 `;
 
 describe('index', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,10 +58,7 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} \
-          --emitter /opt/sd/emitter {{build_id}} &
-          /opt/sd/logservice --api-uri {{store_uri}} --build {{build_id}} &
-          wait $(jobs -p)
+          /opt/sd/run.sh "{{token}}" {{api_uri}} {{store_uri}} $SD_BUILD_TIMEOUT {{build_id}}
 `;
 
 describe('index', () => {
@@ -516,6 +513,7 @@ describe('index', () => {
                     launcher_version: 'stable',
                     build_id: config.buildId,
                     build_id_with_prefix: `${config.buildId}`,
+                    token: config.token,
                     base_image: config.container,
                     memory: '4g',
                     memory_swap: '6g',
@@ -590,6 +588,7 @@ rm -f docker-compose.yml
                     launcher_version: launchVersion,
                     build_id: config.buildId,
                     build_id_with_prefix: `${prefix}${config.buildId}`,
+                    token: config.token,
                     base_image: config.container,
                     memory,
                     memory_swap: memoryLimit,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,8 @@ services:
       - "/bin/sh"
       - "-c"
       - |
-          /opt/sd/run.sh "{{token}}" "{{api_uri}}" "{{store_uri}}" "$SD_BUILD_TIMEOUT" "{{build_id}}"
+          /opt/sd/run.sh "{{token}}" "{{api_uri}}" `
+          + `"{{store_uri}}" "$SD_BUILD_TIMEOUT" "{{build_id}}"
 `;
 
 describe('index', () => {


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To fetch build token in actual build execution, we fixed to exchange temporal token to build token in launcher process. 
However, also log-service uses token which is passed by `executor-*`.
To pass fetched build token to log-service and launcher, add the flag to launcher which only fetch token in launcher process, and use this flag to set fetched token before launcher and log-service processes start.
Detail: https://github.com/screwdriver-cd/screwdriver/issues/1167#issuecomment-409441739

Launcher passes wrapper script to run build. Therefore, each executor uses this script.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Use wrapper script to run build.

## References
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
issue comment: https://github.com/screwdriver-cd/screwdriver/issues/1167#issuecomment-409441739

PR:
launcher: https://github.com/screwdriver-cd/launcher/pull/203
executor-k8s: https://github.com/screwdriver-cd/executor-k8s/pull/89
hyperctl-image: https://github.com/screwdriver-cd/hyperctl-image/pull/24
executor-docker: https://github.com/screwdriver-cd/executor-docker/pull/28