### PR TITLE
feat: Configure the label of Jenkins slave

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -500,7 +500,9 @@ describe('index', () => {
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config), xml);
+                const parsedAnnotations = {};
+
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), xml);
             });
         });
 
@@ -558,7 +560,9 @@ rm -f docker-compose.yml
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config), jobXml);
+                const parsedAnnotations = {};
+
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
 
             it('use provided options correctly', () => {
@@ -573,8 +577,7 @@ rm -f docker-compose.yml
                     jenkins: {
                         host: 'jenkins',
                         username: 'admin',
-                        password: 'fakepassword',
-                        nodeLabel
+                        password: 'fakepassword'
                     },
                     docker: {
                         composeCommand,
@@ -619,13 +622,16 @@ rm -f docker-compose.yml
                     composeYml
                 });
 
+                const providedNodeLabel = 'foo-label';
+                const parsedAnnotations = { nodeLabel: providedNodeLabel };
+
                 jobXml = tinytim.render(TEST_JOB_XML, {
-                    nodeLabel,
+                    nodeLabel: `screwdriver-${providedNodeLabel}`,
                     buildScript: xmlescape(buildScript),
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(executor._loadJobXml(config), jobXml);
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
         });
     });


### PR DESCRIPTION
## Context

To select specific Jenkins node, `nodeLabel` annotation is added in this PR.
If `nodeLabel` is not configured, the job is executed in the slave as default label (screwdriver).

## Objective

To select specific slave, annotation is added in screwdriver.yaml as below.

```
annotations:
  screwdriver.cd/executor: jenkins
  screwdriver.cd/nodeLabel: foo-label
```

## References

related PR: https://github.com/att55/executor-base/pull/1