### PR TITLE
fix: pull in new screwdriver-executor-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hoek": "^5.0.4",
     "jenkins": "^0.20.0",
     "request": "^2.88.0",
-    "screwdriver-executor-base": "^6.1.0",
+    "screwdriver-executor-base": "^7.2.0",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"
   },


### PR DESCRIPTION
## Context

[This](https://github.com/screwdriver-cd/executor-jenkins/pull/29) change requires the latest executor-base (7.2.0)  changed via [this PR](https://github.com/screwdriver-cd/executor-base/pull/59)

## Objective

pull in new [screwdriver-executor-base](https://github.com/screwdriver-cd/executor-base)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
