### PR TITLE
feat(1958): Publish major version. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const jenkins = require('jenkins');
 const xmlescape = require('xml-escape');
 const tinytim = require('tinytim');
 const Breaker = require('circuit-fuses').breaker;
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 
 const password = Symbol('password');
 const baseUrl = Symbol('baseUrl');

--- a/index.js
+++ b/index.js
@@ -116,12 +116,7 @@ class JenkinsExecutor extends Executor {
         // delay between retry attempts
         return new Promise(resolve => {
             setTimeout(resolve, this.cleanupWatchInterval * 1000);
-        }).then(() =>
-            this._jenkinsJobWaitStop(
-                jobName,
-                timeConsumed + this.cleanupWatchInterval
-            )
-        );
+        }).then(() => this._jenkinsJobWaitStop(jobName, timeConsumed + this.cleanupWatchInterval));
     }
 
     /**
@@ -144,10 +139,7 @@ class JenkinsExecutor extends Executor {
             cleanupScript: xmlescape(cleanupScript)
         };
 
-        return tinytim.renderFile(
-            path.resolve(__dirname, './config/job.xml.tim'),
-            variables
-        );
+        return tinytim.renderFile(path.resolve(__dirname, './config/job.xml.tim'), variables);
     }
 
     /**
@@ -189,10 +181,7 @@ class JenkinsExecutor extends Executor {
             ui_uri: this.ecosystem.ui
         };
 
-        const templateFile = path.resolve(
-            __dirname,
-            './config/docker-compose.yml.tim'
-        );
+        const templateFile = path.resolve(__dirname, './config/docker-compose.yml.tim');
         const composeYml = tinytim.renderFile(templateFile, variables);
 
         const buildScript = [
@@ -205,10 +194,7 @@ class JenkinsExecutor extends Executor {
             `${this.composeCommand} up`
         ].join('\n');
 
-        const cleanupScript = [
-            `${this.composeCommand} rm -f -s`,
-            'rm -f docker-compose.yml'
-        ].join('\n');
+        const cleanupScript = [`${this.composeCommand} rm -f -s`, 'rm -f docker-compose.yml'].join('\n');
 
         return { buildScript, cleanupScript };
     }
@@ -261,15 +247,11 @@ class JenkinsExecutor extends Executor {
         this.nodeLabel = options.jenkins.nodeLabel || 'screwdriver';
         this.buildTimeout = options.jenkins.buildTimeout || 90;
         this.maxBuildTimeout = options.jenkins.maxBuildTimeout || 120;
-        this.composeCommand =
-            (options.docker && options.docker.composeCommand) ||
-            'docker-compose';
-        this.launchVersion =
-            (options.docker && options.docker.launchVersion) || 'stable';
+        this.composeCommand = (options.docker && options.docker.composeCommand) || 'docker-compose';
+        this.launchVersion = (options.docker && options.docker.launchVersion) || 'stable';
         this.prefix = (options.docker && options.docker.prefix) || '';
         this.memory = (options.docker && options.docker.memory) || '4g';
-        this.memoryLimit =
-            (options.docker && options.docker.memoryLimit) || '6g';
+        this.memoryLimit = (options.docker && options.docker.memoryLimit) || '6g';
 
         this.buildScript = options.buildScript || '';
         this.cleanupScript = options.cleanupScript || '';
@@ -277,19 +259,14 @@ class JenkinsExecutor extends Executor {
         this.cleanupWatchInterval = options.cleanupWatchInterval || 2;
 
         // need to pass port number in the future
-        this[
-            baseUrl
-        ] = `http://${this.username}:${this[password]}@${this.host}:${this.port}`;
+        this[baseUrl] = `http://${this.username}:${this[password]}@${this.host}:${this.port}`;
         this.jenkinsClient = jenkins({
             baseUrl: this[baseUrl],
             crumbIssuer: true
         });
 
         // eslint-disable-next-line no-underscore-dangle
-        this.breaker = new Breaker(
-            this._jenkinsCommand.bind(this),
-            options.fusebox
-        );
+        this.breaker = new Breaker(this._jenkinsCommand.bind(this), options.fusebox);
     }
 
     /**
@@ -303,9 +280,7 @@ class JenkinsExecutor extends Executor {
      */
     async _start(config) {
         const jobName = this._jobName(config.buildId);
-        const annotations = this.parseAnnotations(
-            hoek.reach(config, 'annotations', { default: {} })
-        );
+        const annotations = this.parseAnnotations(hoek.reach(config, 'annotations', { default: {} }));
 
         const xml = this._loadJobXml(config, annotations);
         // prettier-ignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-jenkins",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Jenkins Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -34,18 +34,18 @@
   ],
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^4.19.0",
-    "eslint-config-screwdriver": "^4.0.0",
+    "eslint": "^7.7.0",
+    "eslint-config-screwdriver": "^5.0.4",
     "mocha": "^8.1.1",
     "mockery": "^2.0.0",
-    "sinon": "^7.1.0"
+    "sinon": "^9.0.3"
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
     "circuit-fuses": "^4.0.4",
-    "jenkins": "^0.20.0",
+    "jenkins": "^0.28.0",
     "request": "^2.88.2",
-    "screwdriver-executor-base": "git://github.com/screwdriver-cd/executor-base.git#hapi-v19",
+    "screwdriver-executor-base": "^8.0.0",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-executor-jenkins",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Jenkins Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 15000",
+    "test": "mocha --recursive --timeout 15000",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -36,16 +36,16 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.0",
     "eslint-config-screwdriver": "^4.0.0",
-    "jenkins-mocha": "^7.0.0",
+    "mocha": "^8.1.1",
     "mockery": "^2.0.0",
     "sinon": "^7.1.0"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.0.4",
     "circuit-fuses": "^4.0.4",
-    "hoek": "^5.0.4",
     "jenkins": "^0.20.0",
-    "request": "^2.88.0",
-    "screwdriver-executor-base": "^7.2.0",
+    "request": "^2.88.2",
+    "screwdriver-executor-base": "git://github.com/screwdriver-cd/executor-base.git#hapi-v19",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-jenkins",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Jenkins Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -286,10 +286,7 @@ describe('index', () => {
             executor.start(config).then(() => {
                 assert.calledWith(breakerMock.runCommand, existsOpts);
                 assert.calledWith(breakerMock.runCommand, createOpts);
-                assert.calledWith(
-                    breakerMock.runCommand,
-                    configuredBuildTimeoutOpts
-                );
+                assert.calledWith(breakerMock.runCommand, configuredBuildTimeoutOpts);
                 done();
             });
         });
@@ -433,10 +430,7 @@ describe('index', () => {
             breakerMock.runCommand.withArgs(stopOpts).resolves(null);
 
             executor.stop({ buildId: config.buildId }).catch(err => {
-                assert.deepEqual(
-                    err.message,
-                    'No jobs in process yet, try later'
-                );
+                assert.deepEqual(err.message, 'No jobs in process yet, try later');
                 done();
             });
         });
@@ -503,15 +497,12 @@ describe('index', () => {
 
             mockery.registerMock('fs', fsMock);
 
-            fsMock.readFileSync
-                .withArgs(sinon.match(/config\/job.xml.tim/))
-                .returns(TEST_JOB_XML);
+            fsMock.readFileSync.withArgs(sinon.match(/config\/job.xml.tim/)).returns(TEST_JOB_XML);
         });
 
         describe('use custom build script', () => {
             const buildScript = '/opt/bin/sd-build-test-<should-escape-xml>';
-            const cleanupScript =
-                '/opt/bin/sd-cleanup-test-<should-escape-xml>';
+            const cleanupScript = '/opt/bin/sd-cleanup-test-<should-escape-xml>';
 
             beforeEach(() => {
                 executor = new Executor({
@@ -536,18 +527,13 @@ describe('index', () => {
 
                 const parsedAnnotations = {};
 
-                assert.equal(
-                    executor._loadJobXml(config, parsedAnnotations),
-                    xml
-                );
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), xml);
             });
         });
 
         describe('use docker-compose', () => {
             beforeEach(() => {
-                fsMock.readFileSync
-                    .withArgs(sinon.match(/config\/docker-compose.yml.tim/))
-                    .returns(TEST_COMPOSE_YAML);
+                fsMock.readFileSync.withArgs(sinon.match(/config\/docker-compose.yml.tim/)).returns(TEST_COMPOSE_YAML);
             });
 
             it('use default options correctly', () => {
@@ -600,10 +586,7 @@ rm -f docker-compose.yml
 
                 const parsedAnnotations = {};
 
-                assert.equal(
-                    executor._loadJobXml(config, parsedAnnotations),
-                    jobXml
-                );
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
 
             it('use provided options correctly without nodeLabel', () => {
@@ -672,10 +655,7 @@ rm -f docker-compose.yml
 
                 const parsedAnnotations = {};
 
-                assert.equal(
-                    executor._loadJobXml(config, parsedAnnotations),
-                    jobXml
-                );
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
 
             it('use provided options correctly with nodeLabel', () => {
@@ -744,10 +724,7 @@ rm -f docker-compose.yml
                     cleanupScript: xmlescape(cleanupScript)
                 });
 
-                assert.equal(
-                    executor._loadJobXml(config, parsedAnnotations),
-                    jobXml
-                );
+                assert.equal(executor._loadJobXml(config, parsedAnnotations), jobXml);
             });
         });
     });
@@ -772,22 +749,10 @@ rm -f docker-compose.yml
                 }
             });
 
-            jenkinsMock.job.create = sinon.stub(
-                executor.jenkinsClient.job,
-                'create'
-            );
-            jenkinsMock.job.config = sinon.stub(
-                executor.jenkinsClient.job,
-                'config'
-            );
-            jenkinsMock.job.exists = sinon.stub(
-                executor.jenkinsClient.job,
-                'exists'
-            );
-            jenkinsMock.job.build = sinon.stub(
-                executor.jenkinsClient.job,
-                'build'
-            );
+            jenkinsMock.job.create = sinon.stub(executor.jenkinsClient.job, 'create');
+            jenkinsMock.job.config = sinon.stub(executor.jenkinsClient.job, 'config');
+            jenkinsMock.job.exists = sinon.stub(executor.jenkinsClient.job, 'exists');
+            jenkinsMock.job.build = sinon.stub(executor.jenkinsClient.job, 'build');
 
             sinon.stub(executor, '_loadJobXml').returns(fakeXml);
         });


### PR DESCRIPTION
## Context

Upgrade to latest hapi js version v19 supported and stable version

## Objective

This PR publishes a new version of the package

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
