### PR TITLE
fix(1961): Remove request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@hapi/hoek": "^9.0.4",
     "circuit-fuses": "^4.0.4",
     "jenkins": "^0.28.0",
-    "request": "^2.88.2",
     "screwdriver-executor-base": "^8.0.0",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"


### PR DESCRIPTION
## Context

Request package is deprecated.

## Objective

This PR removes the unused request package from the package.json.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
