### PR TITLE
fix: API changeed in node-jenkins 1.0.1

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,19 +203,19 @@ describe('index', () => {
             createOpts = {
                 module: 'job',
                 action: 'create',
-                params: [{ name: jobName, xml: fakeXml }]
+                params: [jobName, fakeXml]
             };
 
             configOpts = {
                 module: 'job',
                 action: 'config',
-                params: [{ name: jobName, xml: fakeXml }]
+                params: [jobName, fakeXml]
             };
 
             existsOpts = {
                 module: 'job',
                 action: 'exists',
-                params: [{ name: jobName }]
+                params: [jobName]
             };
 
             buildOpts = {
@@ -349,19 +349,19 @@ describe('index', () => {
             getOpts = {
                 module: 'job',
                 action: 'get',
-                params: [{ name: jobName }]
+                params: [jobName]
             };
 
             stopOpts = {
                 module: 'build',
                 action: 'stop',
-                params: [{ name: jobName, number: buildNumber }]
+                params: [jobName, buildNumber]
             };
 
             destroyOpts = {
                 module: 'job',
                 action: 'destroy',
-                params: [{ name: jobName }]
+                params: [jobName]
             };
         });
 
@@ -773,15 +773,12 @@ rm -f docker-compose.yml
         });
 
         it('calls jenkins function correctly', done => {
-            jenkinsMock.job.exists.yieldsAsync(null, false);
-            jenkinsMock.job.create.yieldsAsync(null);
-            jenkinsMock.job.build.yieldsAsync(null);
+            jenkinsMock.job.exists.resolves(false);
+            jenkinsMock.job.create.resolves(null);
+            jenkinsMock.job.build.resolves(null);
 
             executor.start(config).then(() => {
-                assert.calledWith(jenkinsMock.job.create, {
-                    name: jobName,
-                    xml: fakeXml
-                });
+                assert.calledWith(jenkinsMock.job.create, jobName, fakeXml);
                 assert.calledWith(jenkinsMock.job.build, {
                     name: jobName,
                     parameters: buildParams


### PR DESCRIPTION
## Context

The version of the node-jenkins package was updated to 1.0.1 by https://github.com/screwdriver-cd/executor-jenkins/pull/39, but it was not working properly due to API specification changes.

The 1.0.1 version uses async/await as shown below.
```
await jenkins.job.exists("example");
```
https://github.com/silas/node-jenkins/tree/1.0.1

## Objective

Changed to work properly with node-jenkins version 1.0.1.

## References

There is no github issue, but running the current executor-jenkins results in the following error.

```
Error: jenkins: job.exists: name required
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
