### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-jenkins",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Jenkins Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -46,7 +46,7 @@
     "@hapi/hoek": "^10.0.1",
     "circuit-fuses": "^5.0.0",
     "jenkins": "^1.0.1",
-    "screwdriver-executor-base": "^9.0.0",
+    "screwdriver-executor-base": "^10.0.0",
     "tinytim": "^0.1.1",
     "xml-escape": "^1.1.0"
   },


### PR DESCRIPTION

BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config


## Context

Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
